### PR TITLE
Version of repos set to avoid error when compilating for UWP

### DIFF
--- a/ros2_dotnet_uwp.repos
+++ b/ros2_dotnet_uwp.repos
@@ -6,7 +6,7 @@ repositories:
   eProsima/Fast-RTPS:
     type: git
     url: https://github.com/eProsima/Fast-RTPS.git
-    version: master
+    version: faa62dec0f402274edea3700cf5e654b65492a42
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
@@ -34,7 +34,7 @@ repositories:
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: master
+    version: db27f0e8619460848d80c1442f7fec0c56ee63e5
   ros2/rmw:
     type: git
     url: https://github.com/ros2/rmw.git


### PR DESCRIPTION
Hi @esteve ,

I set the version in ros2_dotnet_uwp.repos because master versions make errors during compilation.

Hope it helps!!