### PR TITLE
Fixing azure pipelines for PR and branchs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ steps:
     set PATH=%PATH%;C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin
     md \dev\ament\src
     cd \dev\ament
-    curl -sk https://raw.githubusercontent.com/esteve/ros2_dotnet/%BUILD_SOURCEBRANCHNAME%/ament_dotnet_uwp.repos -o ament_dotnet_uwp.repos
+    copy $(Build.Repository.LocalPath)\ament_dotnet_uwp.repos \dev\ament\ament_dotnet_uwp.repos
     vcs import src < ament_dotnet_uwp.repos
     python src\ament\ament_tools\scripts\ament.py build --cmake-args -G "Visual Studio 15 2017 Win64" --
     call install\local_setup.bat
@@ -37,7 +37,7 @@ steps:
     set PATH=%PATH%;C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin
     md \dev\ros2\src
     cd \dev\ros2
-    curl -sk https://raw.githubusercontent.com/esteve/ros2_dotnet/%BUILD_SOURCEBRANCHNAME%/ros2_dotnet_uwp.repos -o ros2_dotnet_uwp.repos
+    copy $(Build.Repository.LocalPath)\ros2_dotnet_uwp.repos \dev\ros2\ros2_dotnet_uwp.repos
     vcs import src < ros2_dotnet_uwp.repos
     cd \dev\ros2\src\ros2_dotnet
     vcs custom --git --args checkout %BUILD_SOURCEBRANCHNAME% || VER>NUL
@@ -61,7 +61,7 @@ steps:
     set PATH=%PATH%;C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin
     md \dev\ros2\src
     cd \dev\ros2
-    curl -sk https://raw.githubusercontent.com/esteve/ros2_dotnet/%BUILD_SOURCEBRANCHNAME%/ros2_dotnet.repos -o ros2_dotnet.repos
+    copy $(Build.Repository.LocalPath)\ros2_dotnet.repos \dev\ros2\ros2_dotnet.repos
     vcs import src < ros2_dotnet.repos
     cd \dev\ros2\src\ros2_dotnet
     vcs custom --git --args checkout %BUILD_SOURCEBRANCHNAME% || VER>NUL


### PR DESCRIPTION
Hi @esteve,

In azure-pipelines.yml there is a problem using curl. For example, in:

`curl -sk https://raw.githubusercontent.com/esteve/ros2_dotnet/%BUILD_SOURCEBRANCHNAME%/ament_dotnet_uwp.repos -o ament_dotnet_uwp.repos
`
- repo is fixed to `esteve`. If I make a PR, it will try to bring `ament_dotnet_uwp.repos` from a branch in `esteve`'s repo, instead of `fmrico`
- `BUILD_SOURCEBRANCHNAME` is also a problem. If I make a PR, this variable sets to `merge`.

After some other complex solutions, I found one that takes advantage of that all the code (PR or not) is copied into $(Build.Repository.LocalPath), so I suggest to use the  `ament_dotnet_uwp.repos` that exist in that directory. It is valid for any PR of any user, or a local commit, or a manual build.

Hope it helps !!!


